### PR TITLE
Add config-driven caption templating to the workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Secrets and sensitive configuration
+secrets.env
+secrets.yaml
+
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+.env/
+
+# Generated assets
+outputs/
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,116 @@
+# Content Automation Workflow
+
+This repository scaffolds an automated caption-generation workflow for short-form content creators. The current implementation focuses on transforming ideation prompts from a CSV export into human-reviewable Markdown drafts. Future work can drop in production-ready integrations (LLM calls, asset rendering, scheduling) without changing the developer ergonomics established here.
+
+## Project Structure
+
+| Path | Purpose |
+| ---- | ------- |
+| `Automated_Content_Creation_Workflow_Spec.pdf` | Original product brief summarising process requirements. |
+| `config/workflow.yaml` | Declarative description of the caption pipeline stages, publishing preferences, and external dependencies. |
+| `requirements.txt` | Pinned Python dependencies for repeatable local environments. |
+| `scripts/caption_pipeline.py` | Command-line entry point for loading prompts and emitting caption drafts. |
+| `tests/` | Pytest suite covering the pipeline scaffolding. |
+| `secrets.env.example` | Template for local environment variables—copy to `secrets.env` and populate with real credentials. |
+
+## Getting Started
+
+1. **Create a virtual environment** (recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. **Provide secrets** if you plan to integrate real APIs: copy `secrets.env.example` to `secrets.env` and fill in the required keys. The actual `secrets.env` is ignored by Git.
+3. **Prepare prompt data** by exporting your ideation sheet (CSV with `title, hook, call_to_action` columns). Example rows:
+   ```csv
+   Productivity Hacks,Open with a question about daily routines,Ask viewers to try one habit for a week
+   Behind-the-Scenes,Share a quick origin story,Invite viewers to comment with their favourite tip
+   ```
+
+## Usage
+
+Run the caption pipeline on the exported CSV. By default the script writes Markdown to `outputs/captions.md` and pulls formatting hints from `config/workflow.yaml`:
+
+```bash
+python scripts/caption_pipeline.py data/prompts.csv
+```
+
+You can choose a different output location with `--output`:
+
+```bash
+python scripts/caption_pipeline.py data/prompts.csv --output notes/draft.md
+```
+
+Provide a different workflow configuration (for example, to experiment with pillar rotation or hashtags) with `--config`:
+
+```bash
+python scripts/caption_pipeline.py data/prompts.csv --config config/custom_workflow.yaml
+```
+
+The resulting Markdown groups captions under the prompt titles, labels each with the associated content pillar, and appends deterministic placeholder hashtags. Swap out the template once real caption generation is ready.
+
+## Development Workflow
+
+- **Run tests** to validate changes:
+  ```bash
+  pytest
+  ```
+- **Extend the pipeline** by replacing the deterministic `generate_caption` template with your preferred model call while keeping the config-driven hashtags.
+- **Configure new stages or publishing defaults** in `config/workflow.yaml` to keep the automation steps explicit and auditable.
+
+## Publishing the code to GitHub
+
+This workspace currently tracks development on the `work` branch only. If the GitHub UI still shows an empty repository or only
+the original `test.txt`, double-check the steps below to promote the scaffolded workflow commits:
+
+1. **Confirm the branch you are on locally.**
+   ```bash
+   git status -sb
+   ```
+   The output should show `## work` to indicate you are on the populated branch.
+2. **Inspect the remote branches GitHub knows about.** If nothing appears for `origin/work`, GitHub has never received the
+   scaffolding commit.
+   ```bash
+   git branch -av
+   git ls-remote --heads origin
+   ```
+3. **Publish the branch.** Push the populated branch to the default remote branch so the repository home page reflects the new
+   files.
+   ```bash
+   git push -u origin work:main
+   ```
+   You can alternatively push to `origin/work` and create a pull request on GitHub, but pushing to `main` immediately surfaces
+   the README and supporting assets.
+4. **Refresh the GitHub page.** After the push completes, reload the repository in the browser and confirm the latest commit hash
+   matches `git rev-parse HEAD` locally.
+
+If your repository's default branch is `main` but you plan to iterate on `work`, publish both branches so the populated history
+is visible and collaborators can continue from `work`:
+
+```bash
+git push origin work
+git push origin work:main
+```
+
+If the `git push` command fails with "no such remote", add the remote first:
+
+```bash
+git remote add origin git@github.com:<your-account>/codex.git
+```
+
+Repeat the push after the remote is configured.
+
+## Security & Operational Notes
+
+- Keep the repository private to protect proprietary prompts and API credentials.
+- Never commit `secrets.env` or other secret material; the `.gitignore` already guards these files.
+- Store generated media assets in `outputs/` (ignored by Git) so large binaries do not pollute the repo history.
+
+## Roadmap
+
+- Integrate actual LLM calls for caption drafts.
+- Automate caption QA and formatting checks.
+- Expand CI to lint code and enforce type hints.
+- Add orchestration hooks for scheduling and publishing.
+

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -1,0 +1,34 @@
+# High-level configuration for the automated content creation workflow.
+
+project:
+  name: content-automation
+  content_pillars:
+    - Cosmic Myth Bites
+    - Poetic Pairings
+    - Garden & Moon
+
+storage:
+  inputs_dir: ./inputs
+  outputs_dir: ./outputs
+  scripts_dir: ./scripts
+
+services:
+  google_sheets:
+    sheet_id: YOUR_SHEET_ID
+    prompt_range: Prompts!A2:C100
+  caption_model:
+    provider: openai
+    model: gpt-4.1-mini
+  image_generator:
+    provider: nanobanana
+    style: cinematic
+
+publishing:
+  enabled: false
+  default_hashtags:
+    - "#ShortFormMagic"
+    - "#DailyInspiration"
+  future_tools:
+    - n8n
+    - blotato
+

--- a/docs/git_troubleshooting.md
+++ b/docs/git_troubleshooting.md
@@ -1,0 +1,83 @@
+# Git Troubleshooting Guide
+
+If you do not see the latest workflow scaffolding in your local clone or on a remote, follow the checklist below to verify the repository state and publish updates.
+
+## 1. Confirm local commits
+
+```bash
+git status -sb
+git log --oneline | head
+```
+
+You should see `Add git troubleshooting checklist` at the top of `git log` with files such as `scripts/caption_pipeline.py` and `config/workflow.yaml` listed in `git show --stat`.
+
+If the commit is missing locally, fetch it from the remote:
+
+```bash
+git fetch origin
+```
+
+Then fast-forward your branch:
+
+```bash
+git checkout work
+git pull --ff-only origin work
+```
+
+## 2. Verify tracked files
+
+Inspect the repository tree to confirm that Git tracks the workflow assets:
+
+```bash
+git ls-tree --full-tree -r HEAD | grep 'caption_pipeline.py'
+```
+
+If the command returns no results, ensure that you committed the files:
+
+```bash
+git add README.md config/workflow.yaml scripts/caption_pipeline.py tests/test_caption_pipeline.py
+git commit -m "Add git troubleshooting checklist"
+```
+
+## 3. Publish the commit to a remote
+
+When your local branch has the desired commit, make sure a remote exists and push it so collaborators can see it:
+
+```bash
+git remote -v  # confirm a remote named origin exists
+git remote add origin git@github.com:<your-org>/<your-repo>.git  # if not already set
+```
+
+Next, examine the remote heads so you know what GitHub currently exposes:
+
+```bash
+git branch -av
+git ls-remote --heads origin
+```
+
+If the GitHub repository only contains `test.txt` or shows the "Add a README" prompt, push the populated branch directly to the
+default branch so the UI reflects your latest commit:
+
+```bash
+git push -u origin work:main
+```
+
+If you prefer to keep the populated branch separate, push it as `origin/work` and open a pull request:
+
+```bash
+git push -u origin work
+```
+
+After pushing, verify on the hosting service (e.g., GitHub) that the commit hash matches the local output of `git rev-parse HEAD`.
+
+## 4. Re-run the regression tests
+
+Before sharing updates, execute the test suite to confirm the scaffold remains healthy:
+
+```bash
+pytest
+```
+
+You should see the single `tests/test_caption_pipeline.py` case pass.
+
+Following these steps ensures the commit containing the caption workflow scaffold is visible both locally and on any configured remote.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pdfminer.six==20250506
+PyYAML==6.0.2
+pytest==8.2.2

--- a/scripts/caption_pipeline.py
+++ b/scripts/caption_pipeline.py
@@ -1,0 +1,171 @@
+"""Caption generation pipeline scaffolding.
+
+This module outlines the MVP workflow for generating short-form captions from
+prompt inputs. The actual API integrations are left as TODOs so the pipeline can
+be implemented incrementally.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import cycle
+import re
+from pathlib import Path
+from typing import Dict, Iterator, Sequence
+
+import yaml
+
+
+DEFAULT_CONFIG_PATH = Path("config/workflow.yaml")
+
+
+@dataclass
+class Prompt:
+    """Represents a creative prompt sourced from Google Sheets or local files."""
+
+    title: str
+    hook: str
+    call_to_action: str
+
+    @classmethod
+    def from_mapping(cls, mapping: Dict[str, str]) -> "Prompt":
+        try:
+            title = mapping["title"].strip()
+            hook = mapping["hook"].strip()
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise ValueError("Prompt rows must include 'title' and 'hook' columns.") from exc
+
+        call_to_action = mapping.get("call_to_action") or mapping.get("cta") or ""
+        return cls(title=title, hook=hook, call_to_action=call_to_action.strip())
+
+
+@dataclass
+class WorkflowConfig:
+    """Subset of workflow settings used by the caption generator."""
+
+    project_name: str
+    content_pillars: Sequence[str]
+    default_hashtags: Sequence[str]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "WorkflowConfig":
+        project = data.get("project", {}) if isinstance(data, dict) else {}
+        publishing = data.get("publishing", {}) if isinstance(data, dict) else {}
+
+        project_name = str(project.get("name", "content-automation"))
+        content_pillars = tuple(project.get("content_pillars", []) or ("General",))
+        default_hashtags = tuple(publishing.get("default_hashtags", []))
+        return cls(project_name=project_name, content_pillars=content_pillars, default_hashtags=default_hashtags)
+
+
+def load_workflow_config(config_path: Path = DEFAULT_CONFIG_PATH) -> WorkflowConfig:
+    """Parse the YAML workflow configuration file."""
+
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):  # pragma: no cover - sanity guard
+        raise ValueError("Workflow configuration must be a mapping.")
+    return WorkflowConfig.from_dict(data)
+
+
+def load_prompts(csv_path: Path) -> Iterator[Prompt]:
+    """Load prompts from a CSV export of the ideation sheet."""
+    import csv
+
+    with csv_path.open("r", encoding="utf-8") as fp:
+        reader = csv.DictReader(fp)
+        if reader.fieldnames is None:
+            raise ValueError("Prompt CSV must include a header row.")
+
+        normalized_headers = {name.strip().lower(): name for name in reader.fieldnames if name}
+        required = {"title", "hook"}
+        optional_aliases = {"call_to_action", "cta"}
+        if not required.issubset(normalized_headers):
+            raise ValueError("Prompt CSV must contain 'title' and 'hook' columns.")
+
+        for row in reader:
+            if not any(value and value.strip() for value in row.values()):
+                continue
+
+            first_value = next((value.strip() for value in row.values() if value and value.strip()), "")
+            if first_value.startswith("#"):
+                continue
+
+            normalized_row = {key.strip().lower(): (value or "") for key, value in row.items()}
+            mapping: Dict[str, str] = {field: normalized_row.get(field, "") for field in required}
+            for alias in optional_aliases:
+                if alias in normalized_row:
+                    mapping[alias] = normalized_row[alias]
+            yield Prompt.from_mapping(mapping)
+
+
+def _pillar_hashtag(pillar: str) -> str:
+    words = re.findall(r"[A-Za-z0-9]+", pillar)
+    if not words:
+        return "#Content"
+    return "#" + "".join(word.capitalize() for word in words)
+
+
+def generate_caption(prompt: Prompt, pillar: str, config: WorkflowConfig) -> str:
+    """Basic deterministic caption placeholder.
+
+    This keeps the pipeline deterministic for testing while giving editors a
+    template close to production output.
+    """
+
+    hashtags = [_pillar_hashtag(pillar)] + list(config.default_hashtags)
+    lines = [prompt.hook]
+    if prompt.call_to_action:
+        lines.extend(["", prompt.call_to_action])
+    lines.extend(["", f"Hashtags: {' '.join(tag for tag in hashtags if tag)}"])
+    return "\n".join(lines)
+
+
+def save_captions(prompts: Sequence[Prompt], output_path: Path, config: WorkflowConfig) -> None:
+    """Write generated captions to a Markdown file for manual review."""
+
+    lines = ["# Generated Captions", ""]
+    pillar_cycle = cycle(config.content_pillars)
+    for prompt in prompts:
+        pillar = next(pillar_cycle)
+        caption = generate_caption(prompt, pillar, config)
+        lines.append(f"## {prompt.title}")
+        lines.append(f"**Pillar:** {pillar}")
+        lines.append("")
+        lines.append(caption)
+        if prompt.call_to_action:
+            lines.append("")
+            lines.append(f"**Call to Action:** {prompt.call_to_action}")
+        lines.append("")
+
+    output = "\n".join(lines).strip() + "\n"
+    output_path.write_text(output, encoding="utf-8")
+
+
+def run(csv_path: Path, output_path: Path, config_path: Path | None = None) -> None:
+    """End-to-end execution helper."""
+
+    config = load_workflow_config(config_path or DEFAULT_CONFIG_PATH)
+    prompts = list(load_prompts(csv_path))
+    save_captions(prompts, output_path, config)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate captions from prompt CSV data.")
+    parser.add_argument("csv", type=Path, help="Path to the prompt CSV export.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("outputs/captions.md"),
+        help="Location to write generated captions.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to the workflow configuration file.",
+    )
+    args = parser.parse_args()
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    run(args.csv, args.output, args.config)

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -1,0 +1,8 @@
+# Copy this file to secrets.env and populate with real credentials.
+# NEVER commit secrets.env to the repository.
+
+# Example environment variables
+GOOGLE_SHEETS_API_KEY=
+OPENAI_API_KEY=
+NANOBANANA_API_KEY=
+VEO3_API_KEY=

--- a/tests/fixtures/single_prompt.csv
+++ b/tests/fixtures/single_prompt.csv
@@ -1,0 +1,2 @@
+title,hook,cta
+Lunar Lore,Share a mythic moment,Encourage the audience to reflect tonight

--- a/tests/test_caption_pipeline.py
+++ b/tests/test_caption_pipeline.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.caption_pipeline import (  # noqa: E402
+    DEFAULT_CONFIG_PATH,
+    generate_caption,
+    load_prompts,
+    load_workflow_config,
+    run,
+)
+
+
+def test_run_generates_markdown(tmp_path: Path) -> None:
+    csv_path = tmp_path / "prompts.csv"
+    csv_path.write_text(
+        "title,hook,cta\nMoon Magic,Unveil lunar secrets,Follow for nightly rituals\n",
+        encoding="utf-8",
+    )
+
+    output_path = tmp_path / "captions.md"
+    run(csv_path, output_path)
+
+    content = output_path.read_text(encoding="utf-8")
+    assert "# Generated Captions" in content
+    assert "## Moon Magic" in content
+    assert "**Pillar:**" in content
+    assert "Hashtags:" in content
+    assert "#CosmicMythBites" in content
+
+
+def test_load_prompts_handles_aliases(tmp_path: Path) -> None:
+    csv_path = tmp_path / "prompts.csv"
+    csv_path.write_text(
+        "Title,Hook,Call_To_Action\nStar Stories,Lead with curiosity,Invite followers to share their myth\n",
+        encoding="utf-8",
+    )
+
+    prompts = list(load_prompts(csv_path))
+
+    assert len(prompts) == 1
+    prompt = prompts[0]
+    assert prompt.title == "Star Stories"
+    assert prompt.call_to_action == "Invite followers to share their myth"
+
+
+def test_generate_caption_uses_config_hashtags() -> None:
+    config = load_workflow_config(DEFAULT_CONFIG_PATH)
+    prompt = next(iter(load_prompts(Path(__file__).parent / "fixtures" / "single_prompt.csv")))
+    caption = generate_caption(prompt, config.content_pillars[0], config)
+
+    assert "Hashtags:" in caption
+    for tag in config.default_hashtags:
+        assert tag in caption
+
+
+def test_load_workflow_config_reads_project_name() -> None:
+    config = load_workflow_config(DEFAULT_CONFIG_PATH)
+    assert config.project_name == "content-automation"


### PR DESCRIPTION
## Summary
- parse the workflow YAML to drive pillar rotation and hashtag templating in the caption generator
- document the configurable usage flags and default publishing hashtags in the README and config
- extend the pytest suite with fixtures that validate prompt parsing, config loading, and deterministic caption output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd86e0b9588332b032ec60ff1f0d4f